### PR TITLE
fix: invalid conditions to enable custom json policy

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,0 +1,2 @@
+version: 1
+module_version: 0.0.1

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 
   sqs_dlq_enabled = local.enabled && var.sqs_dlq_enabled
 
-  sns_topic_policy_enabled = local.enabled && length(var.allowed_aws_services_for_sns_published) > 0 || length(var.allowed_iam_arns_for_sns_publish) > 0
+  sns_topic_policy_enabled = local.enabled && length(var.allowed_aws_services_for_sns_published) > 0 || length(var.allowed_iam_arns_for_sns_publish) > 0 || length(var.sns_topic_policy_json) > 0
 }
 
 resource "aws_sns_topic" "this" {


### PR DESCRIPTION
## what
- change the `sns_topic_policy_enabled` variable to consider the value of the `sns_topic_policy_json` to determine if a topic policy is enabled

## why
- without the change the module will not use the value for `sns_topic_policy_json` producing the wrong configuration.

## references
- https://github.com/cloudposse/terraform-aws-sns-topic/pull/55



